### PR TITLE
setup file changes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 from codecs import open
 from os import path
 
@@ -29,6 +29,7 @@ setup(
         'ibllib',
         'lazy_ops',
     ],
-    dependency_links=['git+https://github.com/catalystneuro/nwb-conversion-tools.git@fb9703f8e86072f04356883975e5dfffa773913e#egg=nwb-conversion-tools'],
+    dependency_links=['git+https://github.com/catalystneuro/nwb-conversion-tools.git'
+                      '@fb9703f8e86072f04356883975e5dfffa773913e#egg=nwb-conversion-tools'],
     python_requires='>=3.6'
 )


### PR DESCRIPTION
@bendichter can you please install using `pip install -e .` and run the test and see if it works on a unix ?
also, if you could do the same with this `pip install --extra-index-url https://testpypi.python.org/pypi ibl_to_nwb`
Just wanted to be sure this works before releasing in pypi. I have the issue with `ibllib `not working with pip (due to `pyarrow `error on windows machines)