### PR TITLE
Setup Experiment-Specific Metadata

### DIFF
--- a/ibl_to_nwb/updated_conversion/brainwide_map/brainwidemapconverter.py
+++ b/ibl_to_nwb/updated_conversion/brainwide_map/brainwidemapconverter.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 from one.api import ONE
+from neuroconv.utils import load_dict_from_file
 
 from ..iblconverter import IblConverter
 
@@ -6,6 +9,12 @@ from ..iblconverter import IblConverter
 class BrainwideMapConverter(IblConverter):
 
     def get_metadata(self):
+        metadata = super().get_metadata()
+
         one = ONE(base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True)
 
         # TODO: fetch session and subject-level metadata, including comments/notes
+        experiment_metadata = load_dict_from_file(file_path=Path(__file__) / "experiment_metadata.yml")
+
+        metadata["NWBFile"]["experiment_description"] = experiment_metadata["experiment_description"]
+        metadata["NWBFile"]["related_publications"] = experiment_metadata["related_publications"]

--- a/ibl_to_nwb/updated_conversion/brainwide_map/experiment_metadata.yml
+++ b/ibl_to_nwb/updated_conversion/brainwide_map/experiment_metadata.yml
@@ -1,0 +1,4 @@
+NWBFile:
+  experiment_description: |
+      IBL aims to understand the neural basis of decision-making in the mouse by gathering a whole-brain activity map composed of electrophysiological recordings pooled from multiple laboratories. We have systematically recorded from nearly all major brain areas with Neuropixels probes, using a grid system for unbiased sampling and replicating each recording site in at least two laboratories. These data have been used to construct a brain-wide map of activity at single-spike cellular resolution during a decision-making task. In addition to the map, this data set contains other information gathered during the task: sensory stimuli presented to the mouse; mouse decisions and response times; and mouse pose information from video recordings and DeepLabCut analysis.
+  related_publications: https://doi.org/10.6084/m9.figshare.21400815.v6

--- a/ibl_to_nwb/updated_conversion/repeated_site/experiment_metadata.yml
+++ b/ibl_to_nwb/updated_conversion/repeated_site/experiment_metadata.yml
@@ -1,0 +1,4 @@
+NWBFile:
+  experiment_description: |
+      We repeatedly inserted Neuropixels multi-electrode probes targeting the same brain locations (called the repeated site, including posterior parietal cortex, hippocampus, and thalamus) in mice performing the behavioral task.
+  related_publications: https://doi.org/10.1101/2022.05.09.491042

--- a/ibl_to_nwb/updated_conversion/repeated_site/repeatedsiteconverter.py
+++ b/ibl_to_nwb/updated_conversion/repeated_site/repeatedsiteconverter.py
@@ -1,12 +1,20 @@
-from one.api import ONE
-from neuroconv import ConverterPipe
+from pathlib import Path
 
-class RepeatedSiteConverter(ConverterPipe):
-    def __init__(self, session: str, data_interfaces: list):
-        self.session = session
-        super().__init__(data_interfaces=data_interfaces)
-  
+from one.api import ONE
+from neuroconv.utils import load_dict_from_file
+
+from ..iblconverter import IblConverter
+
+
+class RepeatedSiteConverter(IblConverter):
+
     def get_metadata(self):
+        metadata = super().get_metadata()
+
         one = ONE(base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True)
-        
+
         # TODO: fetch session and subject-level metadata, including comments/notes
+        experiment_metadata = load_dict_from_file(file_path=Path(__file__) / "experiment_metadata.yml")
+
+        metadata["NWBFile"]["experiment_description"] = experiment_metadata["experiment_description"]
+        metadata["NWBFile"]["related_publications"] = experiment_metadata["related_publications"]


### PR DESCRIPTION
Sets up the structure for setting experiment-level metadata through YAML files, pointing to corresponding papers and describing each experiment.

Repeated Sites stuff was done before switching to the Brainwide Map stuff.