### PR TITLE
Add atlas info

### DIFF
--- a/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
+++ b/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from shutil import rmtree
 
-from neuroconv.tools.data_transfers import automatic_dandi_upload
 from one.api import ONE
 
 from ibl_to_nwb.updated_conversion.brainwide_map import BrainwideMapConverter
@@ -22,7 +21,6 @@ from ibl_to_nwb.updated_conversion.datainterfaces import (
 
 def convert_session(base_path: Path, session: str, nwbfile_path: str, stub_test: bool = False):
     # Download behavior and spike sorted data for this session
-    session_path = base_path / session
     cache_folder = base_path / session / "cache"
     session_one = ONE(
         base_url="https://openalyx.internationalbrainlab.org",
@@ -89,8 +87,6 @@ def convert_session(base_path: Path, session: str, nwbfile_path: str, stub_test:
         conversion_options=conversion_options,
         overwrite=True,
     )
-    if not stub_test:
-        automatic_dandi_upload(dandiset_id="000409", nwb_folder_path=nwbfile_path.parent, cleanup=True)
     rmtree(cache_folder)
 
 
@@ -101,7 +97,7 @@ session_retrieval_one = ONE(
 )
 sessions = session_retrieval_one.alyx.rest(url="sessions", action="list", tag="2022_Q4_IBL_et_al_BWM")
 
-for session in sessions[:1]:
+for session in sessions:
     session_id = session["id"]
     print(f"Converting session '{session_id}'")
     nwbfile_path = base_path / "nwbfiles" / session_id / f"{session_id}.nwb"

--- a/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
+++ b/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
@@ -95,7 +95,9 @@ def convert_session(base_path: Path, session: str, nwbfile_path: str, stub_test:
 
 base_path = Path("/home/jovyan/IBL/")  # prototype on DANDI Hub for now
 
-session_retrieval_one = ONE()
+session_retrieval_one = ONE(
+    base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True
+)
 sessions = session_retrieval_one.alyx.rest(url="sessions", action="list", tag="2022_Q4_IBL_et_al_BWM")
 
 for session in sessions[:1]:

--- a/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
+++ b/ibl_to_nwb/updated_conversion/brainwide_map/convert_brainwide_map.py
@@ -89,7 +89,8 @@ def convert_session(base_path: Path, session: str, nwbfile_path: str, stub_test:
         conversion_options=conversion_options,
         overwrite=True,
     )
-    automatic_dandi_upload(dandiset_id="000409", nwb_folder_path=nwbfile_path.parent, cleanup=True)
+    if not stub_test:
+        automatic_dandi_upload(dandiset_id="000409", nwb_folder_path=nwbfile_path.parent, cleanup=True)
     rmtree(cache_folder)
 
 
@@ -104,8 +105,10 @@ for session in sessions[:1]:
     session_id = session["id"]
     print(f"Converting session '{session_id}'")
     nwbfile_path = base_path / "nwbfiles" / session_id / f"{session_id}.nwb"
+    nwbfile_path.parent.mkdir(exist_ok=True)
     convert_session(
         base_path=base_path / "ibl_conversion",
         session=session_id,
-        nwbfile_path=nwbfile_path,  # stub_test=True
+        nwbfile_path=nwbfile_path,
+        stub_test=True,
     )

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -38,6 +38,9 @@ class IblSortingInterface(BaseSortingExtractorInterface):
         unit_id_to_cosmos_regions = brain_regions.id2acronym(atlas_id=channel_id_to_atlas_id, mapping="cosmos")
 
         self.recording_extractor.set_property(
+            key="maximum_amplitude_channel", values=unit_id_to_channel_id
+        )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
+        self.recording_extractor.set_property(
             key="allen_location", values=unit_id_to_allen_regions
         )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
         self.recording_extractor.set_property(key="beryl_location", values=unit_id_to_beryl_regions)
@@ -49,6 +52,10 @@ class IblSortingInterface(BaseSortingExtractorInterface):
         if self.has_histology:
             metadata["Ecephys"].update(
                 UnitProperties=[
+                    dict(
+                        name="maximum_amplitude_channel",
+                        description="Channel which has the largest amplitude for this cluster.",
+                    ),
                     dict(
                         name="allen_location",
                         description="Brain region reference in the Allen Mouse Brain Atlas.",

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,11 +1,11 @@
 """The interface for loading spike sorted data via ONE access."""
+from brainbox.io.one import SpikeSortingLoader
+from ibllib.atlas import AllenAtlas
+from ibllib.atlas.regions import BrainRegions
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
 from one.api import ONE
-from brainbox.io.one import SpikeSortingLoader
-from ibllib.atlas import AllenAtlas
-from ibllib.atlas.regions import BrainRegions
 
 from .iblsortingextractor import IblSortingExtractor
 

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,11 +1,7 @@
 """The interface for loading spike sorted data via ONE access."""
-from brainbox.io.one import SpikeSortingLoader
-from ibllib.atlas import AllenAtlas
-from ibllib.atlas.regions import BrainRegions
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
-from one.api import ONE
 
 from .iblsortingextractor import IblSortingExtractor
 
@@ -13,60 +9,35 @@ from .iblsortingextractor import IblSortingExtractor
 class IblSortingInterface(BaseSortingExtractorInterface):
     Extractor = IblSortingExtractor
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-
-        one = ONE(base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True)
-        atlas = AllenAtlas()
-        brain_regions = BrainRegions()
-        spike_sorting_loader = SpikeSortingLoader(
-            eid=self.session, one=one, pname=self.stream_name.split(".")[0], atlas=atlas
-        )
-        _, clusters, channels = spike_sorting_loader.load_spike_sorting()
-
-        self.has_histology = False
-        if spike_sorting_loader.histology not in ["alf", "resolved"]:
-            return
-        self.has_histology = True
-
-        unit_id_to_channel_id = clusters["channels"]
-        channel_id_to_allen_regions = channels["acronym"]
-        channel_id_to_atlas_id = channels["atlas_id"]
-
-        unit_id_to_allen_regions = channel_id_to_allen_regions[unit_id_to_channel_id]
-        unit_id_to_beryl_regions = brain_regions.id2acronym(atlas_id=channel_id_to_atlas_id, mapping="beryl")
-        unit_id_to_cosmos_regions = brain_regions.id2acronym(atlas_id=channel_id_to_atlas_id, mapping="cosmos")
-
-        self.recording_extractor.set_property(
-            key="maximum_amplitude_channel", values=unit_id_to_channel_id
-        )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
-        self.recording_extractor.set_property(
-            key="allen_location", values=unit_id_to_allen_regions
-        )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
-        self.recording_extractor.set_property(key="beryl_location", values=unit_id_to_beryl_regions)
-        self.recording_extractor.set_property(key="cosmos_location", values=unit_id_to_cosmos_regions)
-
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        if self.has_histology:
-            metadata["Ecephys"].update(
-                UnitProperties=[
-                    dict(
-                        name="maximum_amplitude_channel",
-                        description="Channel which has the largest amplitude for this cluster.",
-                    ),
+        if "Ecephys" not in metadata:
+            metadata.update(Ecephys=dict())
+
+        metadata["Ecephys"].update(
+            UnitProperties=[
+                dict(
+                    name="maximum_amplitude_channel",
+                    description="Channel which has the largest amplitude for this cluster.",
+                )
+            ]
+        )
+
+        if "allen_location" in self.sorting_extractor.get_property_keys():
+            metadata["Ecephys"]["UnitProperties"].extend(
+                [
                     dict(
                         name="allen_location",
                         description="Brain region reference in the Allen Mouse Brain Atlas.",
                     ),
                     dict(
                         name="beryl_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
                     ),
                     dict(
                         name="cosmos_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
                     ),
                 ]
             )

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -20,6 +20,6 @@ class IblSortingInterface(BaseSortingExtractorInterface):
 
         if "allen_location" in self.sorting_extractor.get_property_keys():
             for column_name in ["allen_location", "beryl_location", "cosmos_location"]:
-                metadata["Ecephys"]["UnitProperties"].extend(ecephys_metadata["Ecephys"][column_name])
+                metadata["Ecephys"]["UnitProperties"].extend(ecephys_metadata["Ecephys"]["Electrodes"][column_name])
 
         return metadata

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,10 +1,7 @@
 """The interface for loading spike sorted data via ONE access."""
-from pathlib import Path
-
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
-from neuroconv.utils import load_dict_from_file
 
 from .iblsortingextractor import IblSortingExtractor
 
@@ -15,16 +12,33 @@ class IblSortingInterface(BaseSortingExtractorInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
+        if "Ecephys" not in metadata:
+            metadata.update(Ecephys=dict())
 
-        metadata.update(ecephys_metadata)
+        metadata["Ecephys"].update(
+            UnitProperties=[
+                dict(
+                    name="maximum_amplitude_channel",
+                    description="Channel which has the largest amplitude for this cluster.",
+                )
+            ]
+        )
 
         if "allen_location" in self.sorting_extractor.get_property_keys():
             metadata["Ecephys"]["UnitProperties"].extend(
                 [
-                    column
-                    for column in ecephys_metadata["Ecephys"]["Electrodes"]
-                    if column["name"] in ["allen_location", "beryl_location", "cosmos_location"]
+                    dict(
+                        name="allen_location",
+                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                    ),
+                    dict(
+                        name="beryl_location",
+                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
+                    ),
+                    dict(
+                        name="cosmos_location",
+                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
+                    ),
                 ]
             )
 

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,7 +1,11 @@
-"""The interface for loadding spike sorted data via ONE access."""
+"""The interface for loading spike sorted data via ONE access."""
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
+from one.api import ONE
+from brainbox.io.one import SpikeSortingLoader
+from ibllib.atlas import AllenAtlas
+from ibllib.atlas.regions import BrainRegions
 
 from .iblsortingextractor import IblSortingExtractor
 
@@ -9,5 +13,55 @@ from .iblsortingextractor import IblSortingExtractor
 class IblSortingInterface(BaseSortingExtractorInterface):
     Extractor = IblSortingExtractor
 
-    # def get_metadata(self):
-    #    pass  # TODO: add descriptions for all those custom properties
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+        one = ONE(base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True)
+        atlas = AllenAtlas()
+        brain_regions = BrainRegions()
+        spike_sorting_loader = SpikeSortingLoader(
+            eid=self.session, one=one, pname=self.stream_name.split(".")[0], atlas=atlas
+        )
+        _, clusters, channels = spike_sorting_loader.load_spike_sorting()
+
+        self.has_histology = False
+        if spike_sorting_loader.histology not in ["alf", "resolved"]:
+            return
+        self.has_histology = True
+
+        unit_id_to_channel_id = clusters["channels"]
+        channel_id_to_allen_regions = channels["acronym"]
+        channel_id_to_atlas_id = channels["atlas_id"]
+
+        unit_id_to_allen_regions = channel_id_to_allen_regions[unit_id_to_channel_id]
+        unit_id_to_beryl_regions = brain_regions.id2acronym(atlas_id=channel_id_to_atlas_id, mapping="beryl")
+        unit_id_to_cosmos_regions = brain_regions.id2acronym(atlas_id=channel_id_to_atlas_id, mapping="cosmos")
+
+        self.recording_extractor.set_property(
+            key="allen_location", values=unit_id_to_allen_regions
+        )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
+        self.recording_extractor.set_property(key="beryl_location", values=unit_id_to_beryl_regions)
+        self.recording_extractor.set_property(key="cosmos_location", values=unit_id_to_cosmos_regions)
+
+    def get_metadata(self) -> dict:
+        metadata = super().get_metadata()
+
+        if self.has_histology:
+            metadata["Ecephys"].update(
+                UnitProperties=[
+                    dict(
+                        name="allen_location",
+                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                    ),
+                    dict(
+                        name="beryl_location",
+                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                    ),
+                    dict(
+                        name="cosmos_location",
+                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                    ),
+                ]
+            )
+
+        return metadata

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,7 +1,10 @@
 """The interface for loading spike sorted data via ONE access."""
+from pathlib import Path
+
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
+from neuroconv.utils import load_dict_from_file
 
 from .iblsortingextractor import IblSortingExtractor
 
@@ -12,34 +15,11 @@ class IblSortingInterface(BaseSortingExtractorInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        if "Ecephys" not in metadata:
-            metadata.update(Ecephys=dict())
-
-        metadata["Ecephys"].update(
-            UnitProperties=[
-                dict(
-                    name="maximum_amplitude_channel",
-                    description="Channel which has the largest amplitude for this cluster.",
-                )
-            ]
-        )
+        ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
+        metadata.update(ecephys_metadata)
 
         if "allen_location" in self.sorting_extractor.get_property_keys():
-            metadata["Ecephys"]["UnitProperties"].extend(
-                [
-                    dict(
-                        name="allen_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="beryl_location",
-                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="cosmos_location",
-                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
-                ]
-            )
+            for column_name in ["allen_location", "beryl_location", "cosmos_location"]:
+                metadata["Ecephys"]["UnitProperties"].extend(ecephys_metadata["Ecephys"][column_name])
 
         return metadata

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortinginterface.py
@@ -1,7 +1,10 @@
 """The interface for loading spike sorted data via ONE access."""
+from pathlib import Path
+
 from neuroconv.datainterfaces.ecephys.basesortingextractorinterface import (
     BaseSortingExtractorInterface,
 )
+from neuroconv.utils import load_dict_from_file
 
 from .iblsortingextractor import IblSortingExtractor
 
@@ -12,33 +15,16 @@ class IblSortingInterface(BaseSortingExtractorInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        if "Ecephys" not in metadata:
-            metadata.update(Ecephys=dict())
+        ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
 
-        metadata["Ecephys"].update(
-            UnitProperties=[
-                dict(
-                    name="maximum_amplitude_channel",
-                    description="Channel which has the largest amplitude for this cluster.",
-                )
-            ]
-        )
+        metadata.update(ecephys_metadata)
 
         if "allen_location" in self.sorting_extractor.get_property_keys():
             metadata["Ecephys"]["UnitProperties"].extend(
                 [
-                    dict(
-                        name="allen_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="beryl_location",
-                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="cosmos_location",
-                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
+                    column
+                    for column in ecephys_metadata["Ecephys"]["Electrodes"]
+                    if column["name"] in ["allen_location", "beryl_location", "cosmos_location"]
                 ]
             )
 

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -34,8 +34,8 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
         self.has_histology = False
         if spike_sorting_loader.histology not in ["alf", "resolved"]:
             return
-
         self.has_histology = True
+
         ibl_coords = np.empty(shape=(384, 3))
         ibl_coords[:, 0] = channels["x"]
         ibl_coords[:, 1] = channels["y"]

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -26,6 +26,7 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
         one = ONE(base_url="https://openalyx.internationalbrainlab.org", password="international", silent=True)
         atlas = AllenAtlas()
         brain_regions = BrainRegions()
+
         spike_sorting_loader = SpikeSortingLoader(
             eid=self.session, one=one, pname=self.stream_name.split(".")[0], atlas=atlas
         )
@@ -47,17 +48,19 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
             self.recording_extractor.set_property(key="y", values=ccf_coords[:, 1])
             self.recording_extractor.set_property(key="z", values=ccf_coords[:, 2])
         finally:
-            self.recording_extractor.set_property(key="ibl_x", values=ccf_coords[:, 0])
-            self.recording_extractor.set_property(key="ibl_y", values=ccf_coords[:, 1])
-            self.recording_extractor.set_property(key="ibl_z", values=ccf_coords[:, 2])
+            self.recording_extractor.set_property(key="ibl_x", values=ibl_coords[:, 0])
+            self.recording_extractor.set_property(key="ibl_y", values=ibl_coords[:, 1])
+            self.recording_extractor.set_property(key="ibl_z", values=ibl_coords[:, 2])
             self.recording_extractor.set_property(
-                key="allen_location", values=channels["acronym"]
+                key="allen_location", values=list(channels["acronym"])
             )  # Acronyms are symmetric, do not differentiate hemisphere to be consistent with their usage
             self.recording_extractor.set_property(
-                key="beryl_location", values=brain_regions.id2acronym(atlas_id=channels["atlas_id"], mapping="Beryl")
+                key="beryl_location",
+                values=list(brain_regions.id2acronym(atlas_id=channels["atlas_id"], mapping="Beryl")),
             )
             self.recording_extractor.set_property(
-                key="cosmos_location", values=brain_regions.id2acronym(atlas_id=channels["atlas_id"], mapping="Cosmos")
+                key="cosmos_location",
+                values=list(brain_regions.id2acronym(atlas_id=channels["atlas_id"], mapping="Cosmos")),
             )
 
     def get_metadata_schema(self) -> dict:
@@ -96,11 +99,11 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
                     ),
                     dict(
                         name="beryl_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
                     ),
                     dict(
                         name="cosmos_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
+                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
                     ),
                 ]
             )

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -77,7 +77,7 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
 
         ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
 
-        metadata["Ecephys"].update(ElectricalSeriesLf=ecephys_metadata["Ecephys"]["ElectricalSeriesLf"])
+        metadata["Ecephys"].update(ElectricalSeriesAp=ecephys_metadata["Ecephys"]["ElectricalSeriesAp"])
         if self.has_histology:
             metadata["Ecephys"].update(Electrodes=ecephys_metadata["Ecephys"]["Electrodes"])
 

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -1,14 +1,14 @@
 """Data interface wrapper around the SpikeInterface extractor - also sets atlas information."""
 import numpy as np
+from brainbox.io.one import SpikeSortingLoader
+from ibllib.atlas import AllenAtlas
+from ibllib.atlas.regions import BrainRegions
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import (
     BaseRecordingExtractorInterface,
 )
 from neuroconv.utils import get_schema_from_hdmf_class
-from pynwb.ecephys import ElectricalSeries
 from one.api import ONE
-from brainbox.io.one import SpikeSortingLoader
-from ibllib.atlas import AllenAtlas
-from ibllib.atlas.regions import BrainRegions
+from pynwb.ecephys import ElectricalSeries
 
 
 class IblStreamingApInterface(BaseRecordingExtractorInterface):

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -1,4 +1,6 @@
 """Data interface wrapper around the SpikeInterface extractor - also sets atlas information."""
+from pathlib import Path
+
 import numpy as np
 from brainbox.io.one import SpikeSortingLoader
 from ibllib.atlas import AllenAtlas
@@ -6,7 +8,7 @@ from ibllib.atlas.regions import BrainRegions
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import (
     BaseRecordingExtractorInterface,
 )
-from neuroconv.utils import get_schema_from_hdmf_class
+from neuroconv.utils import get_schema_from_hdmf_class, load_dict_from_file
 from one.api import ONE
 from pynwb.ecephys import ElectricalSeries
 
@@ -73,40 +75,11 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        metadata["Ecephys"].update(
-            ElectricalSeriesAp=dict(
-                name="ElectricalSeriesAp", description="Raw acquisition traces for the high-pass (ap) SpikeGLX data."
-            )
-        )
+        ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
+
+        metadata["Ecephys"].update(ElectricalSeriesLf=ecephys_metadata["Ecephys"]["ElectricalSeriesLf"])
         if self.has_histology:
-            metadata["Ecephys"].update(
-                Electrodes=[
-                    dict(
-                        name="ibl_x",
-                        description="Medio-lateral coordinate relative to Bregma, left negative, in micrometers.",
-                    ),
-                    dict(
-                        name="ibl_y",
-                        description="Antero-posterior coordinate relative to Bregma, back negative, in micrometers.",
-                    ),
-                    dict(
-                        name="ibl_z",
-                        description="Dorso-ventral coordinate relative to Bregma, ventral negative, in micrometers.",
-                    ),
-                    dict(
-                        name="allen_location",
-                        description="Brain region reference in the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="beryl_location",
-                        description="Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
-                    dict(
-                        name="cosmos_location",
-                        description="Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.",
-                    ),
-                ]
-            )
+            metadata["Ecephys"].update(Electrodes=ecephys_metadata["Ecephys"]["Electrodes"])
 
         return metadata
 
@@ -142,11 +115,9 @@ class IblStreamingLfInterface(IblStreamingApInterface):
     def get_metadata(self) -> dict:
         metadata = super().get_metadata()
 
-        metadata["Ecephys"].update(
-            ElectricalSeriesLf=dict(
-                name="ElectricalSeriesLf", description="Raw acquisition traces for the high-pass (lf) SpikeGLX data."
-            )
-        )
+        ecephys_metadata = load_dict_from_file(file_path=Path(__file__).parent.parent / "metadata" / "ecephys.yml")
+
+        metadata["Ecephys"].update(ElectricalSeriesLf=ecephys_metadata["Ecephys"]["ElectricalSeriesLf"])
 
         return metadata
 

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblstreaminginterface.py
@@ -49,6 +49,11 @@ class IblStreamingApInterface(BaseRecordingExtractorInterface):
             self.recording_extractor.set_property(key="x", values=ccf_coords[:, 0])
             self.recording_extractor.set_property(key="y", values=ccf_coords[:, 1])
             self.recording_extractor.set_property(key="z", values=ccf_coords[:, 2])
+        except ValueError as exception:
+            if str(exception).endswith("value lies outside of the atlas volume."):
+                pass
+            else:
+                raise exception
         finally:
             self.recording_extractor.set_property(key="ibl_x", values=ibl_coords[:, 0])
             self.recording_extractor.set_property(key="ibl_y", values=ibl_coords[:, 1])

--- a/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
+++ b/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
@@ -1,0 +1,25 @@
+Ecephys:
+  ElectricalSeriesAp:
+    name: ElectricalSeriesAp
+    description: Raw acquisition traces for the high-pass (ap) SpikeGLX.
+  ElectricalSeriesLf:
+    name: ElectricalSeriesLf
+    description: Raw acquisition traces for the high-pass (lf) SpikeGLX.
+  Electrodes:
+    - name: ibl_x
+      description: Medio-lateral coordinate relative to Bregma, left negative, in micrometers.
+    - name: ibl_y
+      description: Antero-posterior coordinate relative to Bregma, back negative, in micrometers.
+    - name: ibl_z
+      description: Dorso-ventral coordinate relative to Bregma, ventral negative, in micrometers.
+    - name: allen_location
+      description: Brain region reference in the Allen Mouse Brain Atlas.
+    - name: beryl_location
+      description: |
+        Brain region reference in the IBL Beryll Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.
+    - name: cosmos_location
+      description: |
+        Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.
+  UnitProperties:
+    - name: maximum_amplitude_channel
+      description: Channel which has the largest amplitude for this cluster.


### PR DESCRIPTION
To the `electrodes` and `units` tables, I have added...

- IBL coordinates, when available, as `ibl_x, ibl_y, ibl_z` with rich explanations of how they differ from CCF v3
- CCFv3 coordinates, when able to be calculated from the IBL coordinates, as `x,y,z`
- Allen Brain Atlas regions as `location`
- They use two other custom ontologies that they say are useful for relating functional areas not described by Allen (I'm hoping they publish an official writeup of it at some point, but I haven't seen anything so far): `beryl_location` and `cosmos_location`


Check out an example file with


```python
import h5py
import fsspec
from fsspec.implementations.cached import CachingFileSystem
from pynwb import NWBHDF5IO
from nwbwidgets import Panel

s3_url = "https://dandiarchive.s3.amazonaws.com/blobs/631/af9/631af947-1de8-4e36-83b5-8c763d9d18f5"
cfs = CachingFileSystem(
    fs=fsspec.filesystem("http"),
    cache_storage="/home/jovyan/fsspec_cache",  # Local folder for the cache
)
file_system = cfs.open(s3_url, "rb")
file = h5py.File(file_system)
io = NWBHDF5IO(file=file, load_namespaces=True)
nwbfile = io.read()

nwb2widget(nwbfile)
```