### PR TITLE
Add all sorting metrics

### DIFF
--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortingextractor.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortingextractor.py
@@ -56,24 +56,25 @@ class IblSortingExtractor(BaseSorting):
             all_unit_properties["maximum_amplitude_channel"].extend(unit_id_to_channel_id)
             all_unit_properties["mean_relative_depth"].extend(clusters["depths"])
 
-            for metric_name in [
-                "amp_max",
-                "amp_min",
-                "amp_median",
-                "amp_std_dB",
-                "contamination",
-                "contamination_alt",
-                "drift",
-                "missed_spikes_est",
-                "noise_cutoff",
-                "presence_ratio",
-                "presence_ratio_std",
-                "slidingRP_viol",
-                "spike_count",
-                "firing_rate",
-                "label",
-            ]:
-                all_unit_properties[metric_name].extend(clusters["metrics"][metric_name])
+            ibl_metric_key_to_property_name = dict(
+                amp_max="maximum_amplitude_channel",
+                amp_min="minimum_amplitude",
+                amp_median="median_amplitude",
+                amp_std_dB="standard_deviation_amplitude",
+                contamination="contamination",
+                contamination_alt="alternative_contamination",
+                drift="drift",
+                missed_spikes_est="missed_spikes_estimate",
+                noise_cutoff="noise_cutoff",
+                presence_ratio="presence_ratio",
+                presence_ratio_std="presence_ratio_standard_deviation",
+                slidingRP_viol="slidingRP_viol",
+                spike_count="spike_count",
+                firing_rate="firing_rate",
+                label="label",
+            )
+            for ibl_metric_key, property_name in ibl_metric_key_to_property_name.items():
+                all_unit_properties[property_name].extend(clusters["metrics"][ibl_metric_key])
 
             if sorting_loader.histology in ["alf", "resolved"]:  # Assume if one probe has histology, the other does too
                 channel_id_to_allen_regions = channels["acronym"]

--- a/ibl_to_nwb/updated_conversion/datainterfaces/iblsortingextractor.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/iblsortingextractor.py
@@ -35,11 +35,7 @@ class IblSortingExtractor(BaseSorting):
 
         sorting_loaders = dict()
         spike_times_by_id = defaultdict(list)  # Cast lists per key as arrays after assembly
-        unit_id_probe_property = list()
-        maximum_amplitude_channel = list()
-        allen_location = list()
-        beryl_location = list()
-        cosmos_location = list()
+        all_unit_properties = defaultdict(list)
         unit_id_per_probe_shift = 0
         for probe_name in probe_names:
             sorting_loader = SpikeSortingLoader(eid=session, one=one, pname=probe_name, atlas=atlas)
@@ -53,25 +49,45 @@ class IblSortingExtractor(BaseSorting):
                 spike_times_by_id[unit_id].append(spike_time)
 
             unit_id_per_probe_shift += number_of_units
-            unit_id_probe_property.extend([probe_name] * number_of_units)
+            all_unit_properties["probe_name"].extend([probe_name] * number_of_units)
 
             # Maximum amplitude channel and locations
             unit_id_to_channel_id = clusters["channels"]
-            maximum_amplitude_channel.extend(unit_id_to_channel_id)
+            all_unit_properties["maximum_amplitude_channel"].extend(unit_id_to_channel_id)
+            all_unit_properties["mean_relative_depth"].extend(clusters["depths"])
+
+            for metric_name in [
+                "amp_max",
+                "amp_min",
+                "amp_median",
+                "amp_std_dB",
+                "contamination",
+                "contamination_alt",
+                "drift",
+                "missed_spikes_est",
+                "noise_cutoff",
+                "presence_ratio",
+                "presence_ratio_std",
+                "slidingRP_viol",
+                "spike_count",
+                "firing_rate",
+                "label",
+            ]:
+                all_unit_properties[metric_name].extend(clusters["metrics"][metric_name])
 
             if sorting_loader.histology in ["alf", "resolved"]:  # Assume if one probe has histology, the other does too
                 channel_id_to_allen_regions = channels["acronym"]
                 channel_id_to_atlas_id = channels["atlas_id"]
 
-                allen_location.extend(list(channel_id_to_allen_regions[unit_id_to_channel_id]))
-                beryl_location.extend(
+                all_unit_properties["allen_location"].extend(list(channel_id_to_allen_regions[unit_id_to_channel_id]))
+                all_unit_properties["beryl_location"].extend(
                     list(
                         brain_regions.id2acronym(
                             atlas_id=channel_id_to_atlas_id[unit_id_to_channel_id], mapping="Beryl"
                         )
                     )
                 )
-                cosmos_location.extend(
+                all_unit_properties["cosmos_location"].extend(
                     list(
                         brain_regions.id2acronym(
                             atlas_id=channel_id_to_atlas_id[unit_id_to_channel_id], mapping="Cosmos"
@@ -90,13 +106,7 @@ class IblSortingExtractor(BaseSorting):
         )
         self.add_sorting_segment(sorting_segment)
 
-        # TODO: add more properties
-        properties = dict(probe_name=unit_id_probe_property, maximum_amplitude_channel=maximum_amplitude_channel)
-        if allen_location:
-            properties.update(
-                allen_location=allen_location, beryl_location=beryl_location, cosmos_location=cosmos_location
-            )
-        for property_name, values in properties.items():
+        for property_name, values in all_unit_properties.items():
             self.set_property(key=property_name, values=np.array(values))
 
 

--- a/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
+++ b/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
@@ -56,11 +56,7 @@ Ecephys:
         The standard deviation of the presence ratio of spike counts over non-empty bins of width of 10 seconds.
     - name: sliding_refractory_period_violation
       description: |
-        A binary metric which determines whether there is an acceptable level of refractory period violations by using a sliding refractory period.
-
-This takes into account the firing rate of the neuron and computes a maximum acceptable level of contamination at different possible values of the refractory period. If the unit has less than the maximum contamination at any of the possible values of the refractory period, the unit passes.
-
-A neuron will always fail this metric for very low firing rates, and thus this metric takes into account both firing rate and refractory period violations.
+        "A binary metric which determines whether there is an acceptable level of refractory period violations by using a sliding refractory period.\nThis takes into account the firing rate of the neuron and computes a maximum acceptable level of contamination at different possible values of the refractory period. If the unit has less than the maximum contamination at any of the possible values of the refractory period, the unit passes.\nA neuron will always fail this metric for very low firing rates, and thus this metric takes into account both firing rate and refractory period violations."
     - name: spike_count
       description: Total number of spikes for each unit.
     - name: firing_rate

--- a/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
+++ b/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
@@ -22,4 +22,42 @@ Ecephys:
         Brain region reference in the IBL Cosmos Atlas, which is a reduced mapping of functionally related regions from the Allen Mouse Brain Atlas.
   UnitProperties:
     - name: maximum_amplitude_channel
-      description: Channel which has the largest amplitude for this cluster.
+      description: Channel which has the largest amplitude for each unit.
+    - name: mean_relative_depth
+      description: Relative mean depth of each unit in micrometers. 0 is the deepest site, positive values are above this.
+    # Cluster metrics start below here
+    - name: maximum_amplitude
+      description: Maximum amplitude of the waveforms for each unit in volts.
+    - name: minimum_amplitude
+      description: Minimum amplitude of the waveforms for each unit in volts.
+    - name: median_amplitude
+      description: Median amplitude of the waveforms for each unit in volts.
+    - name: standard_deviation_amplitude
+      description: TODO
+    - name: contamination
+      description: TODO
+    - name: alternative_contamination
+      description: TODO
+    - name: drift
+      description: TODO
+    - name: missed_spikes_estimate
+      description: TODO
+    - name: noise_cutoff
+      description: TODO
+    - name: presence_ratio
+      description: TODO
+    - name: presence_ratio_standard_deviation
+      description: TODO
+    - name: slidingRP_violation  # RP?
+      description: TODO
+    - name: spike_count
+      description: TODO
+    - name: firing_rate
+      description: TODO
+    - name: label
+      description: TODO
+    - name: spike_amplitudes
+      description: Peak amplitude of each spike for each unit.
+    - name: spike_relative_depths
+      description: |
+        Relative depth along the probe used to detect each spike in micrometers, computed from the waveform center of mass. 0 is the deepest site, positive values are above this.

--- a/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
+++ b/ibl_to_nwb/updated_conversion/metadata/ecephys.yml
@@ -27,35 +27,46 @@ Ecephys:
       description: Relative mean depth of each unit in micrometers. 0 is the deepest site, positive values are above this.
     # Cluster metrics start below here
     - name: maximum_amplitude
-      description: Maximum amplitude of the waveforms for each unit in volts.
+      description: Maximum amplitude of the waveforms for each unit in microvolts.
     - name: minimum_amplitude
-      description: Minimum amplitude of the waveforms for each unit in volts.
+      description: Minimum amplitude of the waveforms for each unit in microvolts.
     - name: median_amplitude
-      description: Median amplitude of the waveforms for each unit in volts.
+      description: Median amplitude of the waveforms for each unit in microvolts.
     - name: standard_deviation_amplitude
-      description: TODO
+      description: Standard deviation of the log-amplitude of the waveforms for each unit in decibels.
     - name: contamination
-      description: TODO
+      description: |
+        "An estimate of the contamination of the unit (i.e. a pseudo false positive measure) based on the number of spikes, number of ISI violations, and time between the first and last spike. See Hill et al. (2011) J Neurosci 31: 8699-8705) for more details."
     - name: alternative_contamination
-      description: TODO
+      description: |
+        "A modified estimate of the contamination of the unit (i.e. a pseudo false positive measure) based on the number of spikes, number of ISI violations, and time between the first and last spike. See Hill et al. (2011) J Neurosci 31: 8699-8705) for more details."
     - name: drift
-      description: TODO
+      description: Average drift of the unit in micrometers.
     - name: missed_spikes_estimate
-      description: TODO
+      description: |
+        "Computes the approximate fraction of spikes missing from a spike feature distribution for a given unit, assuming the distribution is symmetric. Inspired by metrics described in Hill et al. (2011) J Neurosci 31: 8699-8705."
     - name: noise_cutoff
-      description: TODO
+      description: |
+        A new metric to determine whether the amplitude distribution for each unit is cut off (at floor), without assuming a Gaussian distribution. This metric takes the amplitude distribution, computes the mean and standard deviation of an upper quartile of the distribution, and determines how many standard deviations away from that mean a lower quartile lies.
     - name: presence_ratio
-      description: TODO
+      description: |
+        The average presence ratio of spike counts; the number of bins where there is at least one spike, over the total number of bins, given a specified bin width.
     - name: presence_ratio_standard_deviation
-      description: TODO
-    - name: slidingRP_violation  # RP?
-      description: TODO
+      description: |
+        The standard deviation of the presence ratio of spike counts over non-empty bins of width of 10 seconds.
+    - name: sliding_refractory_period_violation
+      description: |
+        A binary metric which determines whether there is an acceptable level of refractory period violations by using a sliding refractory period.
+
+This takes into account the firing rate of the neuron and computes a maximum acceptable level of contamination at different possible values of the refractory period. If the unit has less than the maximum contamination at any of the possible values of the refractory period, the unit passes.
+
+A neuron will always fail this metric for very low firing rates, and thus this metric takes into account both firing rate and refractory period violations.
     - name: spike_count
-      description: TODO
+      description: Total number of spikes for each unit.
     - name: firing_rate
-      description: TODO
+      description: Average firing rate of each unit in Hz.
     - name: label
-      description: TODO
+      description: Proportion of quality metrics passed.
     - name: spike_amplitudes
       description: Peak amplitude of each spike for each unit.
     - name: spike_relative_depths


### PR DESCRIPTION
To the `units` tables, I have added...

- The set of unit metrics automatically returned by the `ibllib` library
- Metadata descriptions for each of these


Check out an example file with


```python
import h5py
import fsspec
from fsspec.implementations.cached import CachingFileSystem
from pynwb import NWBHDF5IO
from nwbwidgets import Panel

s3_url = "https://dandiarchive.s3.amazonaws.com/blobs/631/af9/631af947-1de8-4e36-83b5-8c763d9d18f5"
cfs = CachingFileSystem(
    fs=fsspec.filesystem("http"),
    cache_storage="/home/jovyan/fsspec_cache",  # Local folder for the cache
)
file_system = cfs.open(s3_url, "rb")
file = h5py.File(file_system)
io = NWBHDF5IO(file=file, load_namespaces=True)
nwbfile = io.read()

nwb2widget(nwbfile)
```