### PR TITLE
Change to wheel velocity function

### DIFF
--- a/ibl_to_nwb/updated_conversion/datainterfaces/wheelinterface.py
+++ b/ibl_to_nwb/updated_conversion/datainterfaces/wheelinterface.py
@@ -40,7 +40,7 @@ class WheelInterface(BaseDataInterface):
         interpolated_position, interpolated_timestamps = wheel_methods.interpolate_position(
             re_ts=wheel["timestamps"], re_pos=wheel["position"], freq=interpolation_frequency
         )
-        velocity, acceleration = wheel_methods.velocity_smoothed(
+        velocity, acceleration = wheel_methods.velocity_filtered(
             pos=interpolated_position, freq=interpolation_frequency
         )
 

--- a/ibl_to_nwb/updated_conversion/metadata/wheel.yml
+++ b/ibl_to_nwb/updated_conversion/metadata/wheel.yml
@@ -12,7 +12,7 @@ WheelPosition:
     Absolute unwrapped angle of the wheel from session start. The sign from the subject perspective corresponds to mathematical convention; counter-clockwise is positive. The wheel diameter is 6.2 cm and the number of ticks is 4096 per revolution.
 WheelVelocity:
   name: WheelVelocity
-  description: The velocity estimated using a window size of 3ms and interpolated at a frequency of 1000 Hz, then convolved with a Gaussian window.
+  description: The velocity estimated from the position interpolated at a frequency of 1000 Hz and passed through an 8th order lowpass Butterworth filter.
 WheelAcceleration:
   name: WheelAcceleration
-  description: The acceleration estimated using a window size of 3ms and interpolated at a frequency of 1000 Hz, then convolved with a Gaussian window.
+  description: The acceleration estimated from the position interpolated at a frequency of 1000 Hz and passed through an 8th order lowpass Butterworth filter.


### PR DESCRIPTION
We have deprecated `brainbox.behavior.wheel.velocity_smoothed` in favour of `brainbox.behavior.wheel.velocity_filtered`.  We did this because unlike the Gaussian window convolution, a Butterworth filter is non-causal which is important for neural analysis.  The filtering is necessary to reduce noise caused by imprecision in the recording.  More info in [this pull request](https://github.com/int-brain-lab/ibllib/pull/623).