### PR TITLE
Fix IBL sorting timings

### DIFF
--- a/src/ibl_to_nwb/datainterfaces/_ibl_sorting_extractor.py
+++ b/src/ibl_to_nwb/datainterfaces/_ibl_sorting_extractor.py
@@ -182,7 +182,6 @@ class IblSortingExtractor(BaseSorting):
         for property_name, values in all_unit_properties.items():
             self.set_property(key=property_name, values=values, ids=cluster_ids)
 
-
     def get_unit_spike_train(
         self,
         unit_id: str | int,
@@ -196,13 +195,12 @@ class IblSortingExtractor(BaseSorting):
 
         if return_times is False:
             raise ValueError("return_times must be True for IblSortingExtractor.get_unit_spike_train()")
-        
-        
+
         segment = self._sorting_segments[segment_index]
         segment.get_unit_spike_times(unit_id=unit_id)
 
         spike_times = segment.get_unit_spike_times(unit_id=unit_id)
-        
+
         start_time = start_frame / self.get_sampling_frequency() if start_frame is not None else None
         end_time = end_frame / self.get_sampling_frequency() if end_frame is not None else None
 
@@ -212,6 +210,7 @@ class IblSortingExtractor(BaseSorting):
         if end_time is not None:
             spike_times = spike_times[spike_times < end_time]
         return spike_times
+
 
 class IblSortingSegment(BaseSortingSegment):
     def __init__(self, sampling_frequency: float, spike_times_by_id: Dict[int, np.ndarray]):
@@ -233,7 +232,6 @@ class IblSortingSegment(BaseSortingSegment):
             frames = frames[frames < end_frame]
         return frames
 
-    
     def get_unit_spike_times(self, unit_id: int) -> np.ndarray:
         """
         Get the spike times for a given unit ID.

--- a/src/ibl_to_nwb/datainterfaces/_ibl_sorting_extractor.py
+++ b/src/ibl_to_nwb/datainterfaces/_ibl_sorting_extractor.py
@@ -5,8 +5,13 @@ from typing import Dict, Optional, Union
 
 import numpy as np
 import pandas as pd
-from pydantic import DirectoryPath
+from brainbox.io.one import SpikeSortingLoader
+from iblatlas.atlas import AllenAtlas
+from iblatlas.regions import BrainRegions
+from neuroconv.utils import get_json_schema_from_method_signature
+from one.api import ONE
 from spikeinterface import BaseSorting, BaseSortingSegment
+from tqdm import tqdm
 
 
 class IblSortingExtractor(BaseSorting):
@@ -16,24 +21,36 @@ class IblSortingExtractor(BaseSorting):
     installation_mesg = ""
     name = "iblsorting"
 
-    def __init__(self, session: str, cache_folder: Optional[DirectoryPath] = None):
-        from brainbox.io.one import SpikeSortingLoader
-        from iblatlas.atlas import AllenAtlas
-        from iblatlas.regions import BrainRegions
-        from one.api import ONE
+    def get_source_schema(cls) -> dict:
+        """
+        Infer the JSON schema for the source_data from the method signature (annotation typing).
 
-        one = ONE(
-            base_url="https://openalyx.internationalbrainlab.org",
-            password="international",
-            silent=True,
-            cache_dir=cache_folder,
-        )
+        Returns
+        -------
+        dict
+            The JSON schema for the source_data.
+        """
+        return get_json_schema_from_method_signature(cls, exclude=["source_data", "one"])
+
+    # def __init__(self, session: str, cache_folder: Optional[DirectoryPath] = None, revision: Optional[str] = None):
+    def __init__(
+        self,
+        one: ONE,
+        session: str,
+        revision: Optional[str] = None,
+    ):
+        if revision is None:  # if no revision is specified, use the latest
+            revision = one.list_revisions(session)[-1]
+
         atlas = AllenAtlas()
         brain_regions = BrainRegions()
 
-        dataset_contents = one.list_datasets(eid=session, collection="raw_ephys_data/*")
-        raw_contents = [dataset_content for dataset_content in dataset_contents if not dataset_content.endswith(".npy")]
-        probe_names = set([raw_content.split("/")[1] for raw_content in raw_contents])
+        probe_names = [
+            probe_description["label"] for probe_description in one.load_dataset(session, "probes.description")
+        ]
+        # dataset_contents = one.list_datasets(eid=session, collection="raw_ephys_data/*")
+        # raw_contents = [dataset_content for dataset_content in dataset_contents if not dataset_content.endswith(".npy")]
+        # probe_names = set([raw_content.split("/")[1] for raw_content in raw_contents])
 
         sorting_loaders = dict()
         spike_times_by_id = defaultdict(list)  # Cast lists per key as arrays after assembly
@@ -45,19 +62,43 @@ class IblSortingExtractor(BaseSorting):
         for probe_name in probe_names:
             sorting_loader = SpikeSortingLoader(eid=session, one=one, pname=probe_name, atlas=atlas)
             sorting_loaders.update({probe_name: sorting_loader})
-            spikes, clusters, channels = sorting_loader.load_spike_sorting()
+            spikes, clusters, channels = sorting_loader.load_spike_sorting(revision=revision)
             # cluster_ids.extend(list(np.array(clusters["metrics"]["cluster_id"]) + unit_id_per_probe_shift))
             number_of_units = len(np.unique(spikes["clusters"]))
             cluster_ids.extend(list(np.arange(number_of_units).astype("int32") + unit_id_per_probe_shift))
 
+            # previous by cody
             # TODO - compare speed against iterating over unique cluster IDs + vector index search
-            for spike_cluster, spike_times, spike_amplitudes, spike_depths in zip(
-                spikes["clusters"], spikes["times"], spikes["amps"], spikes["depths"]
-            ):
+            # for spike_cluster, spike_times, spike_amplitudes, spike_depths in zip(
+            #     spikes["clusters"], spikes["times"], spikes["amps"], spikes["depths"]
+            # ):
+            #     unit_id = unit_id_per_probe_shift + spike_cluster
+            #     spike_times_by_id[unit_id].append(spike_times)
+            #     spike_amplitudes_by_id[unit_id].append(spike_amplitudes)
+            #     spike_depths_by_id[unit_id].append(spike_depths)
+
+            # simply numpy indexing - here 2x faster than searchsorted ... ?
+            for spike_cluster in tqdm(np.unique(spikes["clusters"])):
+                ix = np.where(spikes["clusters"] == spike_cluster)[0]
                 unit_id = unit_id_per_probe_shift + spike_cluster
-                spike_times_by_id[unit_id].append(spike_times)
-                spike_amplitudes_by_id[unit_id].append(spike_amplitudes)
-                spike_depths_by_id[unit_id].append(spike_depths)
+                spike_times_by_id[unit_id] = spikes["times"][ix]
+                spike_amplitudes_by_id[unit_id] = spikes["amps"][ix]
+                spike_depths_by_id[unit_id] = spikes["depths"][ix]
+
+            # should outperform but doesn't
+            # pre-sort for fast access
+            # sort_ix = np.argsort(spikes["clusters"])
+            # spikes_times = spikes["times"][sort_ix]
+            # spikes_clusters = spikes["clusters"][sort_ix]
+            # spikes_amps = spikes["amps"][sort_ix]
+            # spikes_depths = spikes["depths"][sort_ix]
+
+            # for spike_cluster in tqdm(np.unique(spikes["clusters"])):
+            #     start_ix, stop_ix = np.searchsorted(spikes_clusters, [spike_cluster, spike_cluster + 1])
+            #     unit_id = unit_id_per_probe_shift + spike_cluster
+            #     spike_times_by_id[unit_id] = spikes_times[start_ix:stop_ix]
+            #     spike_amplitudes_by_id[unit_id] = spikes_amps[start_ix:stop_ix]
+            #     spike_depths_by_id[unit_id] = spikes_depths[start_ix:stop_ix]
 
             unit_id_per_probe_shift += number_of_units
             all_unit_properties["probe_name"].extend([probe_name] * number_of_units)
@@ -113,6 +154,7 @@ class IblSortingExtractor(BaseSorting):
                     )
                 )
 
+        # this is obsolete now
         for unit_id in spike_times_by_id:  # Cast as arrays for fancy indexing
             spike_times_by_id[unit_id] = np.array(spike_times_by_id[unit_id])
             spike_amplitudes_by_id[unit_id] = np.array(spike_amplitudes_by_id[unit_id])
@@ -141,6 +183,36 @@ class IblSortingExtractor(BaseSorting):
             self.set_property(key=property_name, values=values, ids=cluster_ids)
 
 
+    def get_unit_spike_train(
+        self,
+        unit_id: str | int,
+        segment_index: Union[int, None] = None,
+        start_frame: Union[int, None] = None,
+        end_frame: Union[int, None] = None,
+        return_times: bool = False,
+        use_cache: bool = True,
+    ):
+        segment_index = self._check_segment_index(segment_index)
+
+        if return_times is False:
+            raise ValueError("return_times must be True for IblSortingExtractor.get_unit_spike_train()")
+        
+        
+        segment = self._sorting_segments[segment_index]
+        segment.get_unit_spike_times(unit_id=unit_id)
+
+        spike_times = segment.get_unit_spike_times(unit_id=unit_id)
+        
+        start_time = start_frame / self.get_sampling_frequency() if start_frame is not None else None
+        end_time = end_frame / self.get_sampling_frequency() if end_frame is not None else None
+
+        spike_times = segment.get_unit_spike_times(unit_id=unit_id)
+        if start_time is not None:
+            spike_times = spike_times[spike_times >= start_time]
+        if end_time is not None:
+            spike_times = spike_times[spike_times < end_time]
+        return spike_times
+
 class IblSortingSegment(BaseSortingSegment):
     def __init__(self, sampling_frequency: float, spike_times_by_id: Dict[int, np.ndarray]):
         BaseSortingSegment.__init__(self)
@@ -160,3 +232,20 @@ class IblSortingSegment(BaseSortingSegment):
         if end_frame is not None:
             frames = frames[frames < end_frame]
         return frames
+
+    
+    def get_unit_spike_times(self, unit_id: int) -> np.ndarray:
+        """
+        Get the spike times for a given unit ID.
+
+        Parameters
+        ----------
+        unit_id : int
+            The ID of the unit.
+
+        Returns
+        -------
+        np.ndarray
+            The spike times in seconds.
+        """
+        return self._spike_times_by_id[unit_id]


### PR DESCRIPTION
This modifies the sorting extractor to use the timings directly bypassing the times - frames -times translation in Spikeinterface. 

This I branch from the current state of the ibl repo main instead of from this. We need to discuss how to o sync both repos @grg2rsr.